### PR TITLE
ci: migrate to centralized workflows and Knope versioning

### DIFF
--- a/.git-town.toml
+++ b/.git-town.toml
@@ -1,4 +1,21 @@
+
 # See https://www.git-town.com/configuration-file for details
 
 [branches]
 main = "develop"
+
+[create]
+share-new-branches = "no"
+
+[hosting]
+forge-type = "github"
+github-connector = "gh"
+
+[ship]
+delete-tracking-branch = true
+
+[sync]
+feature-strategy = "rebase"
+perennial-strategy = "rebase"
+push-hook = true
+upstream = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,11 @@
+name: Build
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    uses: LumeWeb/workflows/.github/workflows/build-plugin.yml@develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,10 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: LumeWeb/workflows/.github/workflows/release.yml@develop
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/update-ui.yml
+++ b/.github/workflows/update-ui.yml
@@ -1,0 +1,19 @@
+name: Update UI
+
+on:
+  repository_dispatch:
+    types: [update-ui]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  call-workflow:
+    uses: LumeWeb/workflows/.github/workflows/update-ui.yml@develop
+    with:
+      commit_hash: ${{ github.event.client_payload.commit_hash }}
+      app_name: ${{ github.event.client_payload.app_name }}
+      repository: ${{ github.event.client_payload.repository }}
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+node_modules
+pnpm-lock.yaml
+vendor/
+.aider*

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,7 @@
+[package]
+versioned_files = ["go.mod"]
+changelog = "CHANGELOG.md"
+
+[github]
+owner = "LumeWeb"
+repo = "portal-plugin-core"


### PR DESCRIPTION
- Add GitHub Actions workflows using centralized LumeWeb/workflows
- Add build workflow for master/develop branches
- Add release workflow with Knope integration
- Add update-ui workflow for UI dependency updates
- Add Knope configuration for version management
- Add Git Town configuration
- Add gitignore file


---

<!-- kody-pr-summary:start -->
This pull request implements a migration to centralized CI/CD workflows and establishes automated versioning. Specifically, it:

*   **Migrates to Centralized Workflows:** Replaces local GitHub Actions configurations with references to shared workflows from `LumeWeb/workflows` for build, release, and UI update processes.
*   **Configures Knope Versioning:** Sets up Knope to manage versioning based on `go.mod` and generate changelogs.
*   **Updates Git Town Configuration:** Defines branch synchronization strategies (rebase), hosting platform settings (GitHub), and branch tracking behaviors.
*   **Adds `.gitignore`:** Introduces standard exclusions for build artifacts, dependencies (Go and Node), and temporary files.
<!-- kody-pr-summary:end -->