### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,5 +6,4 @@ on:
 jobs:
   release:
     uses: LumeWeb/workflows/.github/workflows/release.yml@develop
-    secrets:
-      PAT: ${{ secrets.PAT }}
+    secrets: inherit


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the release workflow configuration to inherit all secrets from the calling repository, rather than explicitly passing only the `PAT` secret. This change fixes the release workflow by ensuring all necessary secrets are available to the reusable workflow.
<!-- kody-pr-summary:end -->